### PR TITLE
Fix weapon-tier filtering independently of badge display

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6516,11 +6516,10 @@ function evaluateAegisFiltering() {
         const pvePart = result?.pveGrade?.toLowerCase() || (isSplit ? grade.split('|')[0].trim() : '');
         const pvpPart = result?.pvpGrade?.toLowerCase() || (isSplit ? grade.split('|')[1].trim() : '');
 
-        let weaponRank = '';
+        const weaponRank = sheetW?.tier || '';
         let perkRank = '';
         const isTwoTier = !isSplit && (grade.length > 2 || (grade.length === 2 && !grade.endsWith('+') && !grade.endsWith('-')));
         if (isTwoTier) {
-          weaponRank = grade.charAt(0);
           perkRank = grade.substring(1);
         } else if (!isSplit) {
           perkRank = grade;


### PR DESCRIPTION
`aegis:w:>=s` returns no matches for S-tier weapons in Standard and combined PvE/PvP badge modes because the filter extracts the weapon tier from the badge text. Single-grade exotic badges have the same problem.

This change reads the tier from the already-selected spreadsheet weapon instead. It keeps weapon-tier filtering independent of perk grades and badge formatting, preserves the existing spreadsheet selection behavior, and changes only three lines in `src/content.ts`.

Validated with TypeScript checks, a full extension build, and seven targeted regression cases. Also tested the temporary Firefox build in Zen against a live DIM inventory using combined 2-Tier badges and PvE Standard badges, including an S-tier exotic and S-tier weapons with lower perk grades.