### PR TITLE
Keep weapon badges current and attached to their tiles

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6744,9 +6744,21 @@ function reprocessAllElements() {
   evaluateAegisFiltering();
 }
 
-// 1. Observe the DOM for additions or changes to 'data-aegis-item-hash' or 'data-aegis-perk-hashes'
 // Mutations are batched and processed once per animation frame instead of
 // running processElement + opacity sync for every single mutation record.
+const ITEM_ATTRIBUTES = [
+  'data-aegis-item-hash',
+  'data-aegis-item-name',
+  'data-aegis-instance-id',
+  'data-aegis-item-type',
+  'data-aegis-perk-hashes',
+  'data-aegis-perks-data',
+  'data-aegis-active-perk-hashes',
+  'data-aegis-masterwork',
+  'data-aegis-weapon-possible-perks',
+  'data-aegis-armor-perks',
+  'data-aegis-armor-stats',
+];
 const pendingProcessTargets = new Set<HTMLElement>();
 let processFlushScheduled = false;
 
@@ -6770,15 +6782,19 @@ const observer = new MutationObserver((mutations) => {
     const mutation = mutations[i];
 
     // Check if the custom data attributes were modified
-    if (
-      mutation.type === 'attributes' &&
-      (mutation.attributeName === 'data-aegis-item-hash' || mutation.attributeName === 'data-aegis-perk-hashes')
-    ) {
+    if (mutation.type === 'attributes') {
       pendingProcessTargets.add(mutation.target as HTMLElement);
     }
 
     // Check for added nodes that might contain our attributes
     if (mutation.type === 'childList') {
+      const removedBadge = Array.from(mutation.removedNodes).some(node =>
+        node instanceof Element && (node.matches('.aegis-badge') || node.querySelector('.aegis-badge'))
+      );
+      if (removedBadge && mutation.target instanceof Element) {
+        const item = mutation.target.closest<HTMLElement>('[data-aegis-item-hash]');
+        if (item && !item.querySelector('.aegis-badge')) pendingProcessTargets.add(item);
+      }
       mutation.addedNodes.forEach((node) => {
         if (node instanceof HTMLElement) {
           if (node.hasAttribute('data-aegis-item-hash')) {
@@ -6809,7 +6825,7 @@ function startObserver() {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ['data-aegis-item-hash', 'data-aegis-perk-hashes'],
+    attributeFilter: ITEM_ATTRIBUTES,
   });
 }
 startObserver();

--- a/src/content.ts
+++ b/src/content.ts
@@ -5258,7 +5258,9 @@ function injectBadge(el: HTMLElement, result: ScoringResult) {
       return;
     }
   } else {
-    badgeTarget = itemContainer.querySelector('.item-tile, [class*="StoreItem"], [class*="InventoryItem"], [class*="ItemTile"]') as HTMLElement | null;
+    badgeTarget = itemContainer.matches('.item, .item-tile')
+      ? itemContainer
+      : itemContainer.querySelector<HTMLElement>('.item, .item-tile') || itemContainer.querySelector<HTMLElement>('[class*="StoreItem"], [class*="InventoryItem"], [class*="ItemTile"]');
     if (!badgeTarget) {
       badgeTarget = itemContainer;
     }
@@ -5277,6 +5279,7 @@ function injectBadge(el: HTMLElement, result: ScoringResult) {
 
   if (existingBadges.length > 0) {
     badge = existingBadges[0] as HTMLDivElement;
+    if (badge.parentElement !== badgeTarget) badgeTarget.appendChild(badge);
     for (let i = 1; i < existingBadges.length; i++) {
       existingBadges[i].remove();
     }
@@ -5406,7 +5409,7 @@ function injectBadge(el: HTMLElement, result: ScoringResult) {
 function removeBadge(el: HTMLElement) {
   const itemContainer = (el.closest('[data-aegis-item-hash]') as HTMLElement) || el;
   itemContainer.classList.remove('aegis-gold-glow');
-  const badgeTarget = itemContainer.querySelector('.item-tile, [class*="StoreItem"], [class*="InventoryItem"], [class*="ItemTile"]');
+  const badgeTarget = itemContainer.querySelector('.item, .item-tile') || itemContainer.querySelector('[class*="StoreItem"], [class*="InventoryItem"], [class*="ItemTile"]');
   if (badgeTarget) {
     badgeTarget.classList.remove('aegis-gold-glow');
   }

--- a/src/main-world-content.ts
+++ b/src/main-world-content.ts
@@ -26,7 +26,7 @@ function sendDiagnosticLog(msg: string) {
 }
 
 // Global cache for weapon instances to store full perk sets (e.g. from popups)
-const instanceCache: Record<string, { perkHashes: number[]; perksDataMap: Record<number, PerkInfo>; equippedMasterwork?: string }> = {};
+const instanceCache: Record<string, { perkHashes: number[]; activePerkHashes: number[]; perksDataMap: Record<number, PerkInfo>; equippedMasterwork?: string }> = {};
 
 // Manifest database state variables for fast offline lookups
 let manifestDbName: string | null = null;
@@ -680,6 +680,12 @@ const detectPlugCategory = (def: any): string => {
   return ''; // Unknown — will be skipped for Chase List, but still tracked for scoring
 };
 
+function setItemAttribute(el: HTMLElement, name: string, value: string | null) {
+  if (el.getAttribute(name) === value) return;
+  if (value === null) el.removeAttribute(name);
+  else el.setAttribute(name, value);
+}
+
 /**
  * Scans a DOM element for item properties in its React Fiber and writes them to attributes.
  */
@@ -750,12 +756,12 @@ function processElement(el: HTMLElement) {
 
     if (isArmor) {
       const newHash = String(item.hash);
-      el.setAttribute('data-aegis-item-hash', newHash);
-      el.setAttribute('data-aegis-item-name', item.name || 'Unknown Armor');
-      el.setAttribute('data-aegis-item-type', 'armor');
+      setItemAttribute(el, 'data-aegis-item-hash', newHash);
+      setItemAttribute(el, 'data-aegis-item-name', item.name || 'Unknown Armor');
+      setItemAttribute(el, 'data-aegis-item-type', 'armor');
       const instanceId = item.id;
       if (instanceId) {
-        el.setAttribute('data-aegis-instance-id', String(instanceId));
+        setItemAttribute(el, 'data-aegis-instance-id', String(instanceId));
       }
 
       // Extract armor socketed perks / intrinsic archetype
@@ -769,7 +775,7 @@ function processElement(el: HTMLElement) {
         }
       }
       if (armorPerks.length > 0) {
-        el.setAttribute('data-aegis-armor-perks', JSON.stringify(armorPerks));
+        setItemAttribute(el, 'data-aegis-armor-perks', JSON.stringify(armorPerks));
       }
 
       // Extract base stats if available
@@ -781,13 +787,13 @@ function processElement(el: HTMLElement) {
             statsMap[statName.toLowerCase().trim()] = st.base ?? st.value ?? 0;
           }
         }
-        el.setAttribute('data-aegis-armor-stats', JSON.stringify(statsMap));
+        setItemAttribute(el, 'data-aegis-armor-stats', JSON.stringify(statsMap));
       }
 
       // Clear weapon-specific attributes
-      el.removeAttribute('data-aegis-perk-hashes');
-      el.removeAttribute('data-aegis-perks-data');
-      el.removeAttribute('data-aegis-active-perk-hashes');
+      setItemAttribute(el, 'data-aegis-perk-hashes', null);
+      setItemAttribute(el, 'data-aegis-perks-data', null);
+      setItemAttribute(el, 'data-aegis-active-perk-hashes', null);
       return;
     }
 
@@ -960,16 +966,20 @@ function processElement(el: HTMLElement) {
     // Instance ID cache logic (handles async loading and popup-to-grid sync)
     const instanceId = item.id;
     if (instanceId) {
+      const cached = instanceCache[instanceId];
+      if (activePerkHashes.length === 0 && cached) {
+        activePerkHashes = [...cached.activePerkHashes];
+      }
       // If we scanned a complete perk list (>3 perks indicates full perks loaded)
       if (perkHashes.length > 3) {
         instanceCache[instanceId] = {
           perkHashes: [...perkHashes],
+          activePerkHashes: [...activePerkHashes],
           perksDataMap: { ...perksDataMap },
           equippedMasterwork,
         };
-      } else if (instanceCache[instanceId]) {
+      } else if (cached) {
         // If current element lacks perks but we have it in cache, populate it!
-        const cached = instanceCache[instanceId];
         for (const hash of cached.perkHashes) {
           if (!perkHashes.includes(hash)) {
             perkHashes.push(hash);
@@ -989,12 +999,6 @@ function processElement(el: HTMLElement) {
     const newHash = String(item.hash);
     const newPerks = perkHashes.join(',');
 
-    const existingHash = el.getAttribute('data-aegis-item-hash');
-    const existingPerks = el.getAttribute('data-aegis-perk-hashes');
-
-    // Write categorized possible perks for the Chase List BEFORE the early-return check.
-    // We always update this when we have meaningful data, regardless of whether the
-    // perkHashes have changed (e.g. popup has more categorized data than a tile).
     if (possiblePerk1s.length > 0 || possiblePerk2s.length > 0 || possibleBarrels.length > 0) {
       const possiblePerksData = {
         barrels: possibleBarrels.sort(),
@@ -1003,31 +1007,22 @@ function processElement(el: HTMLElement) {
         perk2s: possiblePerk2s.sort(),
         origins: possibleOrigins.sort(),
       };
-      el.setAttribute('data-aegis-weapon-possible-perks', JSON.stringify(possiblePerksData));
+      setItemAttribute(el, 'data-aegis-weapon-possible-perks', JSON.stringify(possiblePerksData));
     }
 
-    // Always write the MW attribute before the early-return check so it's
-    // never skipped on re-scans where only the hash/perks are unchanged.
     if (equippedMasterwork) {
-      el.setAttribute('data-aegis-masterwork', equippedMasterwork);
+      setItemAttribute(el, 'data-aegis-masterwork', equippedMasterwork);
     } else {
-      el.removeAttribute('data-aegis-masterwork');
+      setItemAttribute(el, 'data-aegis-masterwork', null);
     }
 
-    // Optimization: Avoid re-triggering content.ts if no scoring-relevant data changed
-    if (existingHash === newHash && existingPerks === newPerks) {
-      return;
-    }
-
-    // Set attributes for the isolated world content script to read
-    el.setAttribute('data-aegis-item-hash', newHash);
-    el.setAttribute('data-aegis-item-name', item.name || 'Unknown Weapon');
-    el.setAttribute('data-aegis-perk-hashes', newPerks);
-    el.setAttribute('data-aegis-perks-data', JSON.stringify(perksDataMap));
-    el.setAttribute('data-aegis-active-perk-hashes', activePerkHashes.join(','));
-    if (instanceId) {
-      el.setAttribute('data-aegis-instance-id', String(instanceId));
-    }
+    setItemAttribute(el, 'data-aegis-item-hash', newHash);
+    setItemAttribute(el, 'data-aegis-item-name', item.name || 'Unknown Weapon');
+    setItemAttribute(el, 'data-aegis-perk-hashes', newPerks);
+    setItemAttribute(el, 'data-aegis-perks-data', JSON.stringify(perksDataMap));
+    setItemAttribute(el, 'data-aegis-active-perk-hashes', activePerkHashes.join(','));
+    setItemAttribute(el, 'data-aegis-instance-id', instanceId ? String(instanceId) : null);
+    setItemAttribute(el, 'data-aegis-item-type', null);
 
   } catch (e) {
     console.debug('Aegis Overlay: Element scan failed', e);
@@ -1065,12 +1060,13 @@ setInterval(scanPage, 10000);
 // 2. Immediate scan on DOM modifications using MutationObserver.
 // Mutations are batched and processed once per animation frame to avoid
 // running selector queries + fiber walks for every single mutation record.
-const pendingNodes: HTMLElement[] = [];
+const pendingNodes = new Set<HTMLElement>();
 let scanScheduled = false;
 
 function flushPendingNodes() {
   scanScheduled = false;
-  const nodes = pendingNodes.splice(0, pendingNodes.length);
+  const nodes = Array.from(pendingNodes);
+  pendingNodes.clear();
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.isConnected) continue;
@@ -1082,18 +1078,23 @@ function flushPendingNodes() {
   }
 }
 
+const OVERLAY_SELECTOR = '.aegis-badge, .aegis-title-badge, .aegis-popup-summary, [data-aegis-details], #aegis-tooltip';
+
 const observer = new MutationObserver((mutations) => {
-  for (let i = 0; i < mutations.length; i++) {
-    const mutation = mutations[i];
-    if (mutation.addedNodes.length > 0) {
-      mutation.addedNodes.forEach((node) => {
-        if (node instanceof HTMLElement) {
-          pendingNodes.push(node);
-        }
+  for (const mutation of mutations) {
+    const target = mutation.target instanceof Element ? mutation.target : mutation.target.parentElement;
+    if (!target || target.closest(OVERLAY_SELECTOR)) continue;
+    if (mutation.type === 'childList') {
+      const changedNodes = [...mutation.addedNodes, ...mutation.removedNodes];
+      if (changedNodes.every(node => node instanceof Element && node.matches(OVERLAY_SELECTOR))) continue;
+      mutation.addedNodes.forEach(node => {
+        if (node instanceof HTMLElement && !node.matches(OVERLAY_SELECTOR)) pendingNodes.add(node);
       });
     }
+    const item = target.closest<HTMLElement>('[data-aegis-item-hash]') || target.closest<HTMLElement>(SELECTORS);
+    if (item) pendingNodes.add(item);
   }
-  if (pendingNodes.length > 0 && !scanScheduled) {
+  if (pendingNodes.size > 0 && !scanScheduled) {
     scanScheduled = true;
     requestAnimationFrame(flushPendingNodes);
   }
@@ -1705,6 +1706,9 @@ function startObserver() {
   observer.observe(document.body, {
     childList: true,
     subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['src', 'class', 'id'],
   });
   scanPage();
   


### PR DESCRIPTION
Weapon badges can show stale grades/disappear until DIM is refreshed. Updates to active perks and other grading inputs can be missed when the weapon hash and available perk list stay unchanged. Badges can also be attached to a small native icon inside a weapon tile instead of the tile itself, leaving the grade out of view.

This change publishes changed grading attributes independently, detects updates within existing tiles, preserves cached active perks during incomplete scans, and restores removed badges. Badge placement prefers the actual item tile and relocates an existing misplaced badge. Unchanged attributes and overlay-owned mutations are ignored to avoid redundant work and observer loops.

Validated with TypeScript checks, a full extension build, 14 scanner/recovery fixture checks, and 15 badge-rendering checks covering mixed grades, native icon placement, duplicate removal, and Winnower. The combined build was also playtested over three days in Zen Browser against a live DIM inventory.
