### PR TITLE
Coalesce badge opacity updates into an animation frame

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6942,13 +6942,13 @@ function scheduleOpacityUpdate() {
     // perceivable mid-scroll, and running the getComputedStyle walk over every
     // badge each frame is expensive (13%+ of main thread in Firefox profiles).
     if (Date.now() - lastScrollTime < TOOLTIP_SCROLL_SUPPRESS_MS) {
-      setTimeout(tryRun, 150);
+      setTimeout(() => requestAnimationFrame(tryRun), 150);
       return;
     }
     opacityUpdateScheduled = false;
     updateBadgesOpacity();
   };
-  tryRun();
+  requestAnimationFrame(tryRun);
 }
 
 const dimmingObserver = new MutationObserver((mutations) => {


### PR DESCRIPTION
Outside scrolling, `scheduleOpacityUpdate()` runs the opacity sweep synchronously and clears its pending flag before returning. Repeated calls can therefore perform repeated sweeps instead of sharing the scheduled update.

Schedule the initial sweep with `requestAnimationFrame` and return scroll-deferred work to an animation frame as well. This lets repeated requests share one pending sweep while preserving the existing scroll delay. The change is limited to two lines in `src/content.ts`.

Validated with TypeScript checks, a full extension build, and seven scheduler checks covering coalescing, subsequent updates, and scroll deferral. The combined build was also playtested over three days in Zen Browser against a live DIM inventory; no quantitative performance benchmark is claimed, but it "feels" snappier to me! :)
