### PR TITLE
Fix startup when the Explorer already exists

### DIFF
--- a/data/pve-database.json
+++ b/data/pve-database.json
@@ -4864,7 +4864,7 @@
       "perk2": "Jolting Feedback",
       "origin": "Accelerated Assault",
       "source": "Crucible",
-      "notes": "double splash on arc, no sustain but high mag uptime due to origin\\",
+      "notes": "double splash on arc, no sustain but high mag uptime due to origin",
       "rank": "21",
       "tier": "A",
       "mw": "Reload"
@@ -19993,7 +19993,7 @@
         "perk2": "Jolting Feedback",
         "origin": "Accelerated Assault",
         "source": "Crucible",
-        "notes": "double splash on arc, no sustain but high mag uptime due to origin\\",
+        "notes": "double splash on arc, no sustain but high mag uptime due to origin",
         "rank": "21",
         "tier": "A",
         "mw": "Reload"
@@ -35587,7 +35587,7 @@
         "perk2": "Jolting Feedback",
         "origin": "Accelerated Assault",
         "source": "Crucible",
-        "notes": "double splash on arc, no sustain but high mag uptime due to origin\\",
+        "notes": "double splash on arc, no sustain but high mag uptime due to origin",
         "rank": "21",
         "tier": "A",
         "mw": "Reload"

--- a/src/content.ts
+++ b/src/content.ts
@@ -6921,6 +6921,8 @@ function updateBadgesOpacity() {
   });
 }
 
+const diagnosticLogs: string[] = [];
+
 // Run initial scan once script loads
 reprocessAllElements();
 if (!IS_WINNOWER_HOST) {
@@ -6984,8 +6986,6 @@ function startDimmingObserver() {
 startDimmingObserver();
 
 // Diagnostic logging framework
-const diagnosticLogs: string[] = [];
-
 function addDiagnosticLog(msg: string) {
   const time = new Date().toTimeString().split(' ')[0];
   const formatted = `[${time}] ${msg}`;

--- a/src/content.ts
+++ b/src/content.ts
@@ -197,6 +197,31 @@ const AMMO_TYPE_MAP: Record<string, string> = {
   'Other': 'Other'
 };
 
+// Diagnostic logging framework
+const MAX_DIAGNOSTIC_LOGS = 500;
+const diagnosticLogs: string[] = [];
+
+function addDiagnosticLog(msg: string) {
+  const time = new Date().toTimeString().split(' ')[0];
+  const formatted = `[${time}] ${msg}`;
+  diagnosticLogs.push(formatted);
+  if (diagnosticLogs.length > MAX_DIAGNOSTIC_LOGS) {
+    diagnosticLogs.shift();
+  }
+  const content = document.querySelector('.aegis-diagnostic-logs-content');
+  if (content) {
+    content.textContent += `${formatted}\n`;
+    content.scrollTop = content.scrollHeight;
+  }
+}
+
+// Receive logs from main world context
+document.addEventListener('aegis-diagnostic-log', (e: any) => {
+  if (e.detail) {
+    addDiagnosticLog(e.detail);
+  }
+});
+
 let wishlistDb: WishlistDatabase = {};
 let enhancedToNormalMap: Record<number, number> = {};
 let scoringSource = 'aegis';
@@ -6921,8 +6946,6 @@ function updateBadgesOpacity() {
   });
 }
 
-const diagnosticLogs: string[] = [];
-
 // Run initial scan once script loads
 reprocessAllElements();
 if (!IS_WINNOWER_HOST) {
@@ -6985,24 +7008,6 @@ function startDimmingObserver() {
 }
 startDimmingObserver();
 
-// Diagnostic logging framework
-function addDiagnosticLog(msg: string) {
-  const time = new Date().toTimeString().split(' ')[0];
-  const formatted = `[${time}] ${msg}`;
-  diagnosticLogs.push(formatted);
-  const content = document.querySelector('.aegis-diagnostic-logs-content');
-  if (content) {
-    content.textContent += `${formatted}\n`;
-    content.scrollTop = content.scrollHeight;
-  }
-}
-
-// Receive logs from main world context
-document.addEventListener('aegis-diagnostic-log', (e: any) => {
-  if (e.detail) {
-    addDiagnosticLog(e.detail);
-  }
-});
 
 // Setup initial log entry
 addDiagnosticLog('Aegis isolated-world script initialized.');


### PR DESCRIPTION
I found out that Aegis can stop initializing if it starts on a DIM page that already contains the Explorer, even if the panel's closed. This fix moves the diagnostic log initialization before the first scan, so startup completes and later badge updates no longer hit an uninitialized opacity flag.

Validated with TypeScript checks, a full extension build, and 36 startup regression cases, including PvP and mixed mode.
